### PR TITLE
Add browser mode and endpoint flags to the CLI

### DIFF
--- a/crates/kreuzcrawl-cli/Cargo.toml
+++ b/crates/kreuzcrawl-cli/Cargo.toml
@@ -23,6 +23,6 @@ tracing = ["kreuzcrawl/tracing"]
 
 [dependencies]
 clap = { workspace = true }
-kreuzcrawl = { path = "../kreuzcrawl", version = "0.1.0-rc.6", features = ["native-runtime"] }
+kreuzcrawl = { path = "../kreuzcrawl", version = "0.1.0-rc.6", features = ["native-runtime", "browser"] }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/kreuzcrawl-cli/src/main.rs
+++ b/crates/kreuzcrawl-cli/src/main.rs
@@ -2,8 +2,33 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use clap::{Parser, Subcommand};
-use kreuzcrawl::{CrawlConfig, CrawlEngine, PerDomainThrottle, ProxyConfig};
+use clap::{Parser, Subcommand, ValueEnum};
+use kreuzcrawl::{BrowserConfig, BrowserMode, CrawlConfig, CrawlEngine, PerDomainThrottle, ProxyConfig};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum CliBrowserMode {
+    Auto,
+    Always,
+    Never,
+}
+
+impl From<CliBrowserMode> for BrowserMode {
+    fn from(value: CliBrowserMode) -> Self {
+        match value {
+            CliBrowserMode::Auto => BrowserMode::Auto,
+            CliBrowserMode::Always => BrowserMode::Always,
+            CliBrowserMode::Never => BrowserMode::Never,
+        }
+    }
+}
+
+fn build_browser_config(browser_mode: CliBrowserMode, browser_endpoint: Option<String>) -> BrowserConfig {
+    BrowserConfig {
+        mode: browser_mode.into(),
+        endpoint: browser_endpoint,
+        ..Default::default()
+    }
+}
 
 #[derive(Parser)]
 #[command(name = "kreuzcrawl", about = "High-performance web crawler and scraper", version)]
@@ -33,6 +58,12 @@ enum Commands {
         /// Respect robots.txt
         #[arg(long)]
         respect_robots_txt: bool,
+        /// When to use the browser: auto, always, or never
+        #[arg(long, value_enum, default_value_t = CliBrowserMode::Auto)]
+        browser_mode: CliBrowserMode,
+        /// CDP WebSocket endpoint for an external browser
+        #[arg(long)]
+        browser_endpoint: Option<String>,
     },
     /// Crawl a website following links
     Crawl {
@@ -69,6 +100,12 @@ enum Commands {
         /// Stay on the same domain
         #[arg(long)]
         stay_on_domain: bool,
+        /// When to use the browser: auto, always, or never
+        #[arg(long, value_enum, default_value_t = CliBrowserMode::Auto)]
+        browser_mode: CliBrowserMode,
+        /// CDP WebSocket endpoint for an external browser
+        #[arg(long)]
+        browser_endpoint: Option<String>,
     },
     /// Discover all URLs on a website via sitemaps and link extraction
     Map {
@@ -111,6 +148,8 @@ async fn main() {
             user_agent,
             timeout,
             respect_robots_txt,
+            browser_mode,
+            browser_endpoint,
         } => {
             let config = CrawlConfig {
                 user_agent,
@@ -121,6 +160,7 @@ async fn main() {
                     username: None,
                     password: None,
                 }),
+                browser: build_browser_config(browser_mode, browser_endpoint),
                 ..Default::default()
             };
             let engine = CrawlEngine::builder().config(config).build().unwrap();
@@ -154,6 +194,8 @@ async fn main() {
             timeout,
             respect_robots_txt,
             stay_on_domain,
+            browser_mode,
+            browser_endpoint,
         } => {
             let config = CrawlConfig {
                 max_depth: Some(depth),
@@ -168,6 +210,7 @@ async fn main() {
                     username: None,
                     password: None,
                 }),
+                browser: build_browser_config(browser_mode, browser_endpoint),
                 ..Default::default()
             };
             let engine = CrawlEngine::builder()
@@ -274,5 +317,31 @@ async fn main() {
                 std::process::exit(1);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliBrowserMode, build_browser_config};
+    use kreuzcrawl::BrowserMode;
+
+    #[test]
+    fn maps_cli_browser_mode_to_engine_mode() {
+        assert_eq!(build_browser_config(CliBrowserMode::Auto, None).mode, BrowserMode::Auto);
+        assert_eq!(
+            build_browser_config(CliBrowserMode::Always, None).mode,
+            BrowserMode::Always
+        );
+        assert_eq!(
+            build_browser_config(CliBrowserMode::Never, None).mode,
+            BrowserMode::Never
+        );
+    }
+
+    #[test]
+    fn preserves_browser_endpoint() {
+        let endpoint = Some("ws://127.0.0.1:9222/devtools/browser/test".to_string());
+        let config = build_browser_config(CliBrowserMode::Auto, endpoint.clone());
+        assert_eq!(config.endpoint, endpoint);
     }
 }

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -31,6 +31,8 @@ kreuzcrawl scrape <URL> [OPTIONS]
 | `--user-agent <STRING>` | -- | Custom user agent |
 | `--timeout <MS>` | `30000` | Request timeout in milliseconds |
 | `--respect-robots-txt` | `false` | Respect robots.txt |
+| `--browser-mode <MODE>` | `auto` | Browser mode: `auto`, `always`, or `never` |
+| `--browser-endpoint <WS_URL>` | -- | CDP WebSocket endpoint for an external browser |
 
 **Examples:**
 
@@ -43,6 +45,12 @@ kreuzcrawl scrape https://example.com --format markdown
 
 # Scrape through a proxy with custom timeout
 kreuzcrawl scrape https://example.com --proxy http://proxy:8080 --timeout 60000
+
+# Force browser rendering for a JS-heavy page
+kreuzcrawl scrape https://quotes.toscrape.com/js/ --browser-mode always --format markdown
+
+# Connect to an external browser via CDP
+kreuzcrawl scrape https://example.com --browser-endpoint ws://127.0.0.1:9222/devtools/browser/...
 ```
 
 **Output:**
@@ -80,6 +88,8 @@ kreuzcrawl crawl <URL>... [OPTIONS]
 | `--timeout <MS>` | -- | `30000` | Request timeout in milliseconds |
 | `--respect-robots-txt` | -- | `false` | Respect robots.txt |
 | `--stay-on-domain` | -- | `false` | Stay on the same domain |
+| `--browser-mode <MODE>` | -- | `auto` | Browser mode: `auto`, `always`, or `never` |
+| `--browser-endpoint <WS_URL>` | -- | -- | CDP WebSocket endpoint for an external browser |
 
 **Examples:**
 
@@ -95,6 +105,9 @@ kreuzcrawl crawl https://example.com --format markdown --stay-on-domain
 
 # Batch crawl multiple seed URLs
 kreuzcrawl crawl https://example.com https://example.org -d 1
+
+# Force browser rendering during crawl
+kreuzcrawl crawl https://quotes.toscrape.com/js/ --browser-mode always --format markdown
 ```
 
 **Output:**


### PR DESCRIPTION
## Summary

This PR exposes browser configuration in the `kreuzcrawl` CLI for the existing scrape/crawl workflows.

Changes:
- enable browser support in `kreuzcrawl-cli`
- add `--browser-mode <auto|always|never>` to `scrape` and `crawl`
- add `--browser-endpoint <ws://...>` to `scrape` and `crawl`
- document the new flags in the CLI usage guide
- add small unit tests for CLI-to-engine browser config mapping

Closes #3.

## Why

The core engine already supports `BrowserConfig` / `BrowserMode`, but the CLI did not expose any way to:
- force browser rendering for JS-heavy pages
- connect to an external CDP browser
- validate browser-backed crawling without writing code against the library bindings

## Validation

- `cargo test -p kreuzcrawl-cli --bin kreuzcrawl`
- `cargo run -p kreuzcrawl-cli -- scrape -h`
- `cargo run -p kreuzcrawl-cli -- scrape https://quotes.toscrape.com/js/ --browser-mode always --format markdown`
- `cargo run -p kreuzcrawl-cli -- scrape https://quotes.toscrape.com/js/ --browser-mode always`
  - confirmed `browser_used == true`
