### PR TITLE
docs: fix P0/P1 accuracy defects from audit

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -55,7 +55,7 @@ All traits are `Send + Sync` and use `async_trait` (except `CrawlStrategy`, whic
 let engine = create_engine(Some(config))?;
 ```
 
-For the uncommon case of injecting custom trait implementations, the internal builder is accessible inside a crate that depends on `kreuzcrawl` as a path dependency. The traits module is not yet re-exported at the crate root.
+For the uncommon case of injecting custom trait implementations, the internal builder is only reachable from within this crate (e.g. as a workspace member or fork). External projects cannot inject custom trait implementations until the relevant items are re-exported.
 
 The builder calls `config.validate()` before constructing the engine and returns `Result<CrawlEngine, CrawlError>`.
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -55,7 +55,7 @@ All traits are `Send + Sync` and use `async_trait` (except `CrawlStrategy`, whic
 let engine = create_engine(Some(config))?;
 ```
 
-For the uncommon case of injecting custom trait implementations, use the internal builder directly inside your own crate that depends on `kreuzcrawl` as a path dependency with access to the `pub(crate)` surface, or wait for the public traits re-export (tracked in [#42](https://github.com/kreuzberg-dev/kreuzcrawl/issues/42)).
+For the uncommon case of injecting custom trait implementations, the internal builder is accessible inside a crate that depends on `kreuzcrawl` as a path dependency. The traits module is not yet re-exported at the crate root.
 
 The builder calls `config.validate()` before constructing the engine and returns `Result<CrawlEngine, CrawlError>`.
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -43,17 +43,19 @@ The engine is composed of seven pluggable trait objects, each held behind `Arc<d
 
 All traits are `Send + Sync` and use `async_trait` (except `CrawlStrategy`, which is synchronous).
 
+!!! warning "Default implementations are internal"
+    The types named in the "Default Implementation" column (`InMemoryFrontier`, `PerDomainThrottle`, `BfsStrategy`, etc.) live in the `defaults` module, which is `pub(crate)`. You cannot import them directly. To use the defaults, call `create_engine(config)` — it wires up all seven traits automatically. If you need a custom implementation, implement the relevant trait on your own type and pass it through the builder (see the [configuration guide](../guides/configuration.md#builder-pattern)).
+
 ## Builder Pattern
 
 `CrawlEngine` is constructed exclusively through `CrawlEngineBuilder`. Any trait left unset is filled with its default implementation:
 
 ```rust
-let engine = CrawlEngine::builder()
-    .config(config)
-    .frontier(my_frontier)
-    .strategy(DfsStrategy)
-    .build()?;
+// create_engine is the public path — it calls builder() with default trait implementations.
+let engine = create_engine(Some(config))?;
 ```
+
+For the uncommon case of injecting custom trait implementations, use the internal builder directly inside your own crate that depends on `kreuzcrawl` as a path dependency with access to the `pub(crate)` surface, or wait for the public traits re-export (tracked in [#42](https://github.com/kreuzberg-dev/kreuzcrawl/issues/42)).
 
 The builder calls `config.validate()` before constructing the engine and returns `Result<CrawlEngine, CrawlError>`.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,13 +50,13 @@ cargo build --features api,mcp
 
 ## Tests
 
-Unit tests, no network needed:
+To run all tests across the workspace (this includes both unit tests and integration tests, which may hit the network):
 
 ```bash
 cargo test --workspace
 ```
 
-Integration tests hit real websites:
+To run *only* the integration test binaries:
 
 ```bash
 cargo test --workspace --test '*'

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,120 @@
 # Contributing
 
-!!! note "Under Construction"
-    This page is being written. Check back soon.
+## Setup
+
+Rust 1.95 is pinned in `rust-toolchain.toml`. Clone and build:
+
+```bash
+git clone https://github.com/kreuzberg-dev/kreuzcrawl
+cd kreuzcrawl
+cargo build
+```
+
+`rustup` will fetch 1.95 on first run if you don't have it. Most Rust work is under `crates/kreuzcrawl/`.
+
+### Pre-commit
+
+Install [pre-commit](https://pre-commit.com/) once, then wire up both hook types:
+
+```bash
+pip install pre-commit
+pre-commit install --hook-type pre-commit --hook-type commit-msg
+```
+
+It runs automatically on `git commit`. To run it by hand:
+
+```bash
+pre-commit run --all-files
+```
+
+## Feature flags
+
+The default build has no optional dependencies. Add features as needed:
+
+| Feature | What it adds |
+|---------|-------------|
+| `browser` | Headless Chrome via chromiumoxide |
+| `ai` | LLM extraction via liter-llm |
+| `api` | REST API server via Axum |
+| `mcp` | Model Context Protocol server |
+| `mcp-http` | MCP over HTTP (implies `mcp` + `api`) |
+| `tracing` | OpenTelemetry spans |
+| `interact` | Page interaction — click, type, scroll (implies `browser`) |
+| `warc` | WARC archive output |
+
+```bash
+cargo build --features api,mcp
+```
+
+`browser` and `interact` require a Chrome/Chromium binary at runtime. They compile without one but panic the first time you use them.
+
+## Tests
+
+Unit tests, no network needed:
+
+```bash
+cargo test --workspace
+```
+
+Integration tests hit real websites:
+
+```bash
+cargo test --workspace --test '*'
+```
+
+Browser tests need a running Chrome instance. Docker is the least painful way:
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+cargo test --features browser --test browser_tests
+```
+
+CI treats clippy warnings as errors, so run this before pushing:
+
+```bash
+cargo clippy --workspace --all-features --all-targets -- -D warnings
+```
+
+## Code conventions
+
+Formatting is configured in `rustfmt.toml`. `cargo fmt` (or the pre-commit hook) handles it.
+
+Four things that aren't obvious from the code:
+
+- Async runtime is `tokio`. Don't introduce `async-std` or `smol`.
+- Public API types belong in `crates/kreuzcrawl/src/types/`. Internal types live next to the code that uses them.
+- `defaults/` is `pub(crate)`. Don't re-export from it at the crate root without a discussion — the narrow public surface is intentional.
+- Error types go in `error.rs` with `thiserror`. No `anyhow` in library code.
+
+## Commits
+
+[gitfluff](https://github.com/Goldziher/gitfluff) lints commit messages on commit. Format:
+
+```
+<type>(<scope>): <subject>
+
+[optional body]
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`. Scope is the crate or area — `engine`, `api`, `cli`, `python`, etc.
+
+Good example: `fix(engine): respect max_pages limit during batch crawl`
+
+## Pull requests
+
+Branch from `main` using `<type>/<short-description>` — e.g. `feat/streaming-results` or `fix/rate-limiter-overflow`.
+
+Before opening:
+
+1. `cargo fmt --all`
+2. `cargo clippy --workspace --all-features --all-targets -- -D warnings`
+3. `cargo test --workspace`
+4. Update `docs/` if you changed a public API or added a feature.
+
+PR descriptions don't need a template. Say what changed and why. Link the issue if there is one.
+
+CI runs the full binding test suite on each PR. You don't need Ruby, Java, PHP, or Elixir set up locally to work on the Rust core.
+
+## License
+
+Kreuzcrawl is under the [Elastic License 2.0](../LICENSE). Contributing means your changes are covered by it.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,7 +5,37 @@ description: Install Kreuzcrawl for Rust, Python, TypeScript, Ruby, Go, Java, C#
 
 # Installation
 
-Kreuzcrawl provides native bindings for 11 languages plus Docker and CLI distribution. Choose your platform below.
+<div class="cli-hero" markdown>
+
+## CLI
+
+The fastest way to get started. No Rust toolchain needed if you use Homebrew.
+
+=== "Homebrew (macOS / Linux)"
+
+    ```bash
+    brew install kreuzberg-dev/tap/kreuzcrawl
+    ```
+
+=== "Cargo"
+
+    ```bash
+    cargo install kreuzcrawl-cli
+    ```
+
+    With optional features:
+
+    ```bash
+    cargo install kreuzcrawl-cli --features "api,mcp"
+    ```
+
+Verify:
+
+```bash
+kreuzcrawl --version
+```
+
+</div>
 
 ---
 
@@ -226,28 +256,8 @@ docker run --rm -v $(pwd)/output:/output \
 
 ---
 
-## CLI
+## Where to go next
 
-### Homebrew (macOS / Linux)
-
-```bash
-brew install kreuzberg-dev/tap/kreuzcrawl
-```
-
-### Cargo
-
-```bash
-cargo install kreuzcrawl-cli
-```
-
-With optional features:
-
-```bash
-cargo install kreuzcrawl-cli --features "api,mcp"
-```
-
-Verify the installation:
-
-```bash
-kreuzcrawl --version
-```
+- **[Quick start](quickstart.md)** — Scrape a page, run a crawl, and map a site in under five minutes. Covers the CLI and the Rust API side by side.
+- **[Configuration guide](../guides/configuration.md)** — Every `CrawlConfig` field with its default and validation rules. Start here if you need to tune depth, concurrency, or content filtering.
+- **[Features overview](../features.md)** — What the engine can do: browser rendering, LLM extraction, REST API, MCP, WARC output, and more. Useful for figuring out which feature flags you need.

--- a/docs/guides/api-server.md
+++ b/docs/guides/api-server.md
@@ -18,25 +18,24 @@ kreuzcrawl serve --host 0.0.0.0 --port 3000
 
 ### Programmatic
 
+The `api` module is internal. The public entry point is `serve_api`, re-exported from the crate root:
+
 ```rust
-use std::sync::Arc;
-use kreuzcrawl::{CrawlConfig, CrawlEngine};
-use kreuzcrawl::api::serve;
+use kreuzcrawl::{CrawlConfig, serve_api};
 
-let engine = CrawlEngine::builder()
-    .config(CrawlConfig::default())
-    .build()?;
-
-serve("0.0.0.0", 3000, Arc::new(engine)).await?;
+serve_api("0.0.0.0", 3000, CrawlConfig::default()).await?;
 ```
 
-Or with the convenience wrapper that builds the engine internally:
+Pass a custom config if you need non-default crawl settings:
 
 ```rust
-use kreuzcrawl::api::serve_with_config;
-use kreuzcrawl::CrawlConfig;
+use kreuzcrawl::{CrawlConfig, serve_api};
 
-serve_with_config("0.0.0.0", 3000, CrawlConfig::default()).await?;
+serve_api("127.0.0.1", 8080, CrawlConfig {
+    max_concurrent: Some(20),
+    respect_robots_txt: true,
+    ..Default::default()
+}).await?;
 ```
 
 ## Middleware stack
@@ -297,7 +296,5 @@ Error codes map to HTTP status codes:
 | `SERVER_ERROR` | 502 | Upstream server error |
 | `INTERNAL_ERROR` | 500 | Unexpected internal error |
 
-!!! tip "Embedding the router"
-    The `create_router()` function returns an Axum `Router` that can be embedded in your
-    own application or used with Tower's `oneshot` for testing. Pass a shared
-    `Arc<CrawlEngine>` to configure the crawl behaviour.
+!!! note "Feature gate"
+    The server requires the `api` Cargo feature. Add `features = ["api"]` to your `Cargo.toml` dependency, or pass `--features api` to `cargo run`.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -20,7 +20,7 @@ let engine: CrawlEngineHandle = create_engine(Some(CrawlConfig {
 ```
 
 !!! note "Custom strategy and filter types"
-    Alternative crawl strategies (`BestFirstStrategy`, `DfsStrategy`, `AdaptiveStrategy`) and content filters (`Bm25Filter`) exist in the crate's `defaults` module, but that module is not part of the public API. If you need custom crawl behaviour, implement the `CrawlStrategy` or `ContentFilter` traits directly — both are defined in the `kreuzcrawl::traits` module (not yet re-exported; track [#42](https://github.com/kreuzberg-dev/kreuzcrawl/issues/42) for the public traits surface).
+    Alternative crawl strategies (`BestFirstStrategy`, `DfsStrategy`, `AdaptiveStrategy`) and content filters (`Bm25Filter`) exist in the crate's `defaults` module, but that module is not part of the public API. If you need custom crawl behaviour, implement the `CrawlStrategy` or `ContentFilter` traits directly — both are defined in the `kreuzcrawl::traits` module, which is not yet re-exported at the crate root.
 
 ### Builder methods (internal reference)
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -20,7 +20,7 @@ let engine: CrawlEngineHandle = create_engine(Some(CrawlConfig {
 ```
 
 !!! note "Custom strategy and filter types"
-    Alternative crawl strategies (`BestFirstStrategy`, `DfsStrategy`, `AdaptiveStrategy`) and content filters (`Bm25Filter`) exist in the crate's `defaults` module, but that module is not part of the public API. If you need custom crawl behaviour, implement the `CrawlStrategy` or `ContentFilter` traits directly — both are defined in the `kreuzcrawl::traits` module, which is not yet re-exported at the crate root.
+    Alternative crawl strategies (`BestFirstStrategy`, `DfsStrategy`, `AdaptiveStrategy`) and content filters (`Bm25Filter`) exist in the crate's `defaults` module, but that module is not part of the public API. Custom strategies and filters are not currently supported for external use until the relevant traits are re-exported.
 
 ### Builder methods (internal reference)
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -4,26 +4,27 @@ All kreuzcrawl operations are controlled through `CrawlConfig`. This guide cover
 
 ## Builder pattern
 
-The `CrawlEngineBuilder` provides a fluent API for constructing a `CrawlEngine` with custom configuration and trait implementations:
+The engine's trait-based builder (`CrawlEngine::builder()`) is an internal API — it is not re-exported from the crate root. For most use cases, pass a `CrawlConfig` directly to `create_engine`:
 
 ```rust
-use kreuzcrawl::{CrawlEngine, CrawlConfig, BestFirstStrategy, Bm25Filter};
+use kreuzcrawl::{CrawlConfig, CrawlEngineHandle, create_engine};
 
-let engine = CrawlEngine::builder()
-    .config(CrawlConfig {
-        max_depth: Some(3),
-        max_pages: Some(100),
-        max_concurrent: Some(5),
-        stay_on_domain: true,
-        respect_robots_txt: true,
-        ..Default::default()
-    })
-    .strategy(BestFirstStrategy)
-    .content_filter(Bm25Filter::new("rust programming", 0.3))
-    .build()?;
+let engine: CrawlEngineHandle = create_engine(Some(CrawlConfig {
+    max_depth: Some(3),
+    max_pages: Some(100),
+    max_concurrent: Some(5),
+    stay_on_domain: true,
+    respect_robots_txt: true,
+    ..Default::default()
+}))?;
 ```
 
-### Builder methods
+!!! note "Custom strategy and filter types"
+    Alternative crawl strategies (`BestFirstStrategy`, `DfsStrategy`, `AdaptiveStrategy`) and content filters (`Bm25Filter`) exist in the crate's `defaults` module, but that module is not part of the public API. If you need custom crawl behaviour, implement the `CrawlStrategy` or `ContentFilter` traits directly — both are defined in the `kreuzcrawl::traits` module (not yet re-exported; track [#42](https://github.com/kreuzberg-dev/kreuzcrawl/issues/42) for the public traits surface).
+
+### Builder methods (internal reference)
+
+These methods exist on `CrawlEngineBuilder` and are used by `create_engine` internally. They are listed here so you know which defaults are in effect:
 
 | Method | Accepts | Default |
 |---|---|---|
@@ -36,16 +37,14 @@ let engine = CrawlEngine::builder()
 | `.content_filter(impl ContentFilter)` | Post-extraction page filter | `NoopFilter` |
 | `.cache(impl CrawlCache)` | HTTP response cache | `NoopCache` |
 
-All fields are optional. Unset fields use their default implementations from the `defaults` module.
-
-The `.build()` call validates the configuration and returns `Result<CrawlEngine, CrawlError>`.
+Unset fields use their defaults. `create_engine` calls `.build()` which validates the config and returns `Result<CrawlEngineHandle, CrawlError>`.
 
 ## Convenience constructors
 
-For simple use cases that do not need custom trait implementations, use the binding functions:
+For most use cases, `create_engine` plus one of the top-level async functions is all you need:
 
 ```rust
-use kreuzcrawl::{create_engine, scrape, crawl, map_urls};
+use kreuzcrawl::{CrawlConfig, create_engine, scrape, crawl, map_urls};
 
 let engine = create_engine(Some(CrawlConfig {
     max_depth: Some(2),
@@ -58,6 +57,31 @@ let map_result = map_urls(&engine, "https://example.com").await?;
 ```
 
 Passing `None` to `create_engine` uses `CrawlConfig::default()`.
+
+For scraping or crawling multiple URLs in one go, use the batch variants. Each URL runs concurrently; failures are captured per-URL rather than bubbling up as an error:
+
+```rust
+use kreuzcrawl::{create_engine, batch_scrape, batch_crawl};
+
+let engine = create_engine(None)?;
+
+let scrape_results = batch_scrape(&engine, vec![
+    "https://example.com".into(),
+    "https://example.org".into(),
+]).await;
+
+let crawl_results = batch_crawl(&engine, vec![
+    "https://example.com".into(),
+    "https://example.org".into(),
+]).await;
+
+// Each entry in the Vec has .url, .result (Option<_>), and .error (Option<String>).
+for r in &scrape_results {
+    if let Some(err) = &r.error {
+        eprintln!("{}: {}", r.url, err);
+    }
+}
+```
 
 ## Config validation
 


### PR DESCRIPTION

## Related

<!-- Link issues or discussions if applicable -->

## Description

- guides/configuration.md: replace builder example that referenced non-exported CrawlEngine, BestFirstStrategy, and Bm25Filter with create_engine(); add pub(crate) note; add batch_scrape/batch_crawl examples
- guides/api-server.md: replace kreuzcrawl::api::serve paths (pub(crate)) with public serve_api alias; drop internal create_router() tip
- contributing.md: replace 4-line stub with full dev setup, feature flags, test commands, code style, and PR workflow
- concepts/architecture.md: warn that default implementations are pub(crate) and cannot be imported; fix builder example to use create_engine()
- getting-started/installation.md: move CLI section to top with cli-hero card styling; add where-to-go-next section

## Checklist

- [ ] CI passing
- [ ] Tests added where applicable
