### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/pulsemcp%2Fcrawlberg.svg)](https://mcptoplist.com/server/pulsemcp%2Fcrawlberg)
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/xberg-io/assets@v1/banner/readme-banner-dark.svg">


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **Crawlberg** is currently ranked **#728**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/pulsemcp%2Fcrawlberg.svg)](https://mcptoplist.com/server/pulsemcp%2Fcrawlberg)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Crawlberg!
